### PR TITLE
feat: Discord reaction approval for plans + share requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -663,7 +663,85 @@ async function main(): Promise<void> {
   // Conditionally connect Discord
   if (DISCORD_BOT_TOKEN) {
     try {
-      const discord = new DiscordChannel(DISCORD_BOT_TOKEN);
+      const discord = new DiscordChannel({
+        token: DISCORD_BOT_TOKEN,
+        onReaction: (chatJid, messageId, emoji) => {
+          // Only handle approval emojis
+          if (!emoji.startsWith('👍') && emoji !== '❤️' && emoji !== '✅') return;
+
+          // 1. Check for share_request approval first
+          const request = consumeShareRequest(messageId);
+          if (request) {
+            const mainJid = Object.entries(registeredGroups).find(
+              ([, g]) => g.folder === MAIN_GROUP_FOLDER,
+            )?.[0];
+            if (!mainJid) return;
+
+            logger.info(
+              { messageId, emoji, sourceGroup: request.sourceGroup, sourceName: request.sourceName },
+              'Share request approved via Discord reaction',
+            );
+
+            const writePaths = request.serverFolder
+              ? `groups/${request.sourceGroup}/CLAUDE.md and/or groups/${request.serverFolder}/CLAUDE.md`
+              : `groups/${request.sourceGroup}/CLAUDE.md`;
+            const syntheticContent = [
+              `Share request APPROVED from ${request.sourceName} (${request.sourceJid}):`,
+              '',
+              `${request.description}`,
+              '',
+              `Fulfill this request — write context to ${writePaths}, clone repos if needed.`,
+              `When done, use send_message to ${request.sourceJid} to notify them: "Your context request has been fulfilled! [brief summary] — check your CLAUDE.md and workspace for updates."`,
+            ].join('\n');
+
+            storeMessage({
+              id: `synth-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              chat_jid: mainJid,
+              sender: 'system',
+              sender_name: 'System',
+              content: syntheticContent,
+              timestamp: new Date().toISOString(),
+              is_from_me: false,
+            });
+
+            queue.enqueueMessageCheck(mainJid);
+            return;
+          }
+
+          // 2. Generic approval: pipe to active container or store as synthetic message
+          const group = registeredGroups[chatJid];
+          if (!group) return;
+
+          logger.info(
+            { chatJid, messageId, emoji, group: group.name },
+            'Reaction approval on bot message in Discord',
+          );
+
+          const approvalContent = `@${ASSISTANT_NAME} [Approved via reaction] Proceed with the plan.`;
+
+          // Try to pipe directly to active container
+          if (!queue.sendMessage(chatJid, formatMessages([{
+            id: `react-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            chat_jid: chatJid,
+            sender: 'system',
+            sender_name: 'System',
+            content: approvalContent,
+            timestamp: new Date().toISOString(),
+          }]))) {
+            // No active container — store in DB and enqueue
+            storeMessage({
+              id: `react-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              chat_jid: chatJid,
+              sender: 'system',
+              sender_name: 'System',
+              content: approvalContent,
+              timestamp: new Date().toISOString(),
+              is_from_me: false,
+            });
+            queue.enqueueMessageCheck(chatJid);
+          }
+        },
+      });
       await discord.connect();
       channels.push(discord);
 


### PR DESCRIPTION
## Summary
- Adds reaction listening to Discord bot (👍 ❤️ ✅ on bot messages)
- Enables **plan approval via reaction** — when the agent posts a plan and waits for confirmation, a 👍 reaction feeds approval back to the container agent
- Enables **share_request approval on Discord** — same reaction flow as WhatsApp, now works on Discord messages too
- Discord `sendMessage` now returns the message ID (enables share_request tracking)

## How it works
1. Bot adds `GuildMessageReactions` intent + `Message`/`Reaction` partials
2. `MessageReactionAdd` events on bot messages trigger `onReaction` callback
3. First checks if the message is a tracked share_request → existing approval flow
4. Otherwise pipes a generic "Proceed with the plan" message to the active container (or stores it for a new container if idle)

## Test plan
- [ ] Verify Discord bot connects with new intents
- [ ] React 👍 to a bot plan message → agent should proceed with execution
- [ ] React 👍 to a share_request message on Discord → should approve and fulfill
- [ ] Verify non-approval emojis are ignored
- [ ] Verify reactions on non-bot messages are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)