### PR TITLE
Add list_agents MCP tool for agent discovery (updated for PR #9)

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -566,6 +566,107 @@ server.tool(
   },
 );
 
+server.tool(
+  'list_agents',
+  `List all registered agents in the NanoClaw system. Use this to discover available agents for communication.
+
+Returns information about each agent including their ID, name, description, backend type, and JID (for messaging).
+This is useful when you need to send messages to specific agents or request context from them.`,
+  {
+    filter_backend: z.enum(['apple-container', 'docker', 'sprites', 'daytona', 'railway']).optional()
+      .describe('Optional: filter agents by backend type'),
+    include_self: z.boolean().default(true)
+      .describe('Include the current agent in results (default: true)'),
+  },
+  async (args) => {
+    const registryPath = path.join(IPC_DIR, 'agent_registry.json');
+
+    try {
+      if (!fs.existsSync(registryPath)) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'Agent registry not found. No agents registered yet.'
+          }]
+        };
+      }
+
+      const registry = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+
+      if (!Array.isArray(registry) || registry.length === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'No agents found in registry.'
+          }]
+        };
+      }
+
+      // Filter agents
+      let agents = registry;
+
+      if (args.filter_backend) {
+        agents = agents.filter((a: any) => a.backend === args.filter_backend);
+      }
+
+      if (!args.include_self) {
+        agents = agents.filter((a: any) => a.id !== groupFolder);
+      }
+
+      if (agents.length === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'No agents match your filter criteria.'
+          }]
+        };
+      }
+
+      // Format output as a table-like structure
+      const lines = ['Available Agents:', ''];
+
+      for (const agent of agents) {
+        const isCurrent = agent.id === groupFolder ? ' (current)' : '';
+        const mainBadge = agent.isMain ? ' [MAIN]' : '';
+        const localBadge = agent.isLocal ? ' [LOCAL]' : ' [CLOUD]';
+
+        lines.push(`*${agent.name}*${isCurrent}${mainBadge}${localBadge}`);
+        lines.push(`  • ID: \`${agent.id}\``);
+        lines.push(`  • JID: \`${agent.jid}\``);
+        if (agent.jids && agent.jids.length > 1) {
+          lines.push(`  • All JIDs: ${agent.jids.map((j: string) => `\`${j}\``).join(', ')}`);
+        }
+        lines.push(`  • Backend: ${agent.backend}`);
+        lines.push(`  • Trigger: ${agent.trigger}`);
+
+        if (agent.description) {
+          lines.push(`  • Description: ${agent.description}`);
+        }
+
+        lines.push('');
+      }
+
+      const summary = `Found ${agents.length} agent${agents.length !== 1 ? 's' : ''}`;
+      const text = `${summary}\n\n${lines.join('\n')}`;
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text
+        }]
+      };
+    } catch (err) {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Error reading agent registry: ${err instanceof Error ? err.message : String(err)}`
+        }],
+        isError: true,
+      };
+    }
+  },
+);
+
 // Start the stdio transport
 const transport = new StdioServerTransport();
 await server.connect(transport);


### PR DESCRIPTION
## Summary
- Adds new `list_agents` MCP tool to help agents discover other agents in the system
- Updated to work with PR #9's new architecture (agent-channel decoupling, S3 storage)
- Simplifies agent-to-agent communication by providing an easy discovery mechanism

## Changes
- **New Tool**: `list_agents` in `container/agent-runner/src/ipc-mcp-stdio.ts`
  - Query all registered agents from agent_registry.json
  - Filter by backend type (apple-container, sprites, daytona, *railway*)
  - Include/exclude self (optional)
  - Returns formatted agent information (ID, name, JID(s), backend, trigger, description)
  - Shows LOCAL/CLOUD and MAIN badges
  - Supports multi-channel agents (displays all JIDs)

## Updates from Original PR #8
This is an updated version of #8 that works with PR #9's merged changes:
- ✅ Added `railway` to backend filter enum
- ✅ Added isLocal badge (LOCAL vs CLOUD)
- ✅ Support for multiple JIDs (jids array from agent-channel decoupling)
- ✅ Compatible with PR #9's new agent registry format

## Benefits
1. **Easier Discovery**: Agents can now query available agents without parsing JSON manually
2. **Better Communication**: Clear visibility into agent JIDs for messaging
3. **Dynamic Routing**: Enables intelligent routing based on agent capabilities and backend
4. **Error Reduction**: Structured output reduces mistakes when agents try to communicate
5. **Multi-Channel Aware**: Shows all JIDs for agents with multiple channel routes

## Example Usage
```typescript
// List all agents
await list_agents({})

// List only cloud agents
await list_agents({ filter_backend: 'railway' })

// List other agents (exclude self)
await list_agents({ include_self: false })
```

## Example Output
```
Found 4 agents

*main* [MAIN] [LOCAL]
  • ID: `main`
  • JID: `12055407422@s.whatsapp.net`
  • Backend: apple-container
  • Trigger: @Omni
  • Description: Admin control portal, always-on cloud agent

*Ditto Discord* [CLOUD]
  • ID: `ditto-discord`
  • JID: `dc:940321040482074705`
  • All JIDs: `dc:940321040482074705`, `dc:940321040482074706`
  • Backend: sprites
  • Trigger: @Omni
  • Description: Ditto project development, frontend/backend repos
```

## Testing
- ✅ TypeScript type checking passed
- ✅ Project builds successfully (`bun run build`)
- ✅ No breaking changes to existing functionality
- ✅ Compatible with PR #9's architecture

## Related
- Original PR #8: https://github.com/omniaura/nanoclaw/pull/8 (closed, superseded by this)
- PR #9 (merged): https://github.com/omniaura/nanoclaw/pull/9
- Analysis: See `/workspace/group/pr-comparison-analysis.md` and `/workspace/group/integration-tasks.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)