### PR TITLE
fix: persist auto-respond config in database

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -185,10 +185,10 @@ export class WhatsAppChannel implements Channel {
       }
     });
 
-    this.sock.ev.on('messages.reaction', (reactions) => {
+    this.sock.ev.on('messages.reaction', async (reactions) => {
       for (const { key, reaction } of reactions) {
         if (!reaction?.text || !key.id || !key.remoteJid) continue;
-        const chatJid = this.translateJid(key.remoteJid);
+        const chatJid = await this.translateJid(key.remoteJid);
         this.opts.onReaction?.(chatJid, key.id, reaction.text);
       }
     });


### PR DESCRIPTION
## Summary

- Add `auto_respond_to_questions` and `auto_respond_keywords` columns to `registered_groups` table with ALTER TABLE migration
- Update `getRegisteredGroup`, `getAllRegisteredGroups`, and `setRegisteredGroup` to read/write the new fields
- Fix pre-existing async bug in WhatsApp reaction handler (`translateJid` returns a Promise but wasn't being awaited)

Without this fix, the `autoRespondToQuestions` and `autoRespondKeywords` fields from the smart-auto-respond feature (#feat/smart-auto-respond) were defined on the `RegisteredGroup` type but never persisted to SQLite, so they were lost on every restart.

## Test plan
- [x] TypeScript compiles cleanly
- [x] Set auto-respond config via sqlite3, restart NanoClaw, verify config loads
- [x] Send message containing keyword in Discord channel — should auto-respond without @mention
- [ ] Send question (ending with ?) — should auto-respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)