### PR TITLE
feat: Add @AllAgents shortcut to ping all Discord bots

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -47,6 +47,7 @@ export class DiscordChannel implements Channel {
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.GuildMessageReactions,
+        GatewayIntentBits.GuildMembers, // Required for guild.members.fetch() in @AllAgents feature
       ],
       partials: [Partials.Channel, Partials.Message, Partials.Reaction],
     });


### PR DESCRIPTION
## Summary

Adds a **@AllAgents** shortcut that automatically pings all Discord agent bots in the server - no more manually typing out every bot mention!

## Usage

```
@AllAgents can you review this PR?
@allagents what are your thoughts on this?
```

## How It Works

1. Detects `@AllAgents` or `@allagents` (case-insensitive) in message
2. Fetches all bot members from the Discord server
3. Excludes self to prevent self-ping
4. Replaces `@AllAgents` with actual bot mentions
5. Logs the number of agents pinged for visibility

## Benefits

- ✅ **Convenient**: Single shortcut instead of typing multiple mentions
- ✅ **Dynamic**: Automatically discovers all bots (no hardcoded list)
- ✅ **Case-insensitive**: `@AllAgents` or `@allagents` both work
- ✅ **Safe**: Prevents self-ping
- ✅ **Observable**: Logs agent count for debugging

## Example

**Before:**
```
<@1472054395515568179> <@1471198154434154508> <@1471707818632548445> can you help?
```

**After:**
```
@AllAgents can you help?
```

## Implementation Details

- Searches registered groups for Discord channels (`dc:` JIDs)
- Fetches guild members and filters for bots
- Creates unique set of bot mentions
- Expands shortcut before normal message processing

## Testing

- ✅ Build passes
- ✅ No behavior changes for non-`@AllAgents` messages
- ✅ Graceful error handling if guild/members fetch fails

## Future Enhancements

Could add:
- `@AllAgentsHere` to ping only bots in current channel
- `@Agents[role]` to ping bots with specific roles
- Rate limiting for spam prevention

---

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * @AllAgents shortcut now available in Discord channels: type @AllAgents (case-insensitive) to expand into mentions for all registered bots.
  * Expansion deduplicates mentions and skips bots that cannot be mentioned.
  * Expansion preserves existing trigger behavior and continues when some bots cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->