### PR TITLE
feat: Add just command runner to container image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -25,6 +25,16 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/home/bun/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
+# Install just command runner (required for ditto backend development)
+ARG JUST_VERSION=1.41.1
+RUN ARCH="$(dpkg --print-architecture)" \
+    && JUST_ARCH=$([ "$ARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") \
+    && wget -q "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
+    && tar -xzf "just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
+    && mv just /usr/local/bin/just \
+    && chmod +x /usr/local/bin/just \
+    && rm "just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz"
+
 # Install GitHub CLI for PR creation and git authentication
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary
- Adds `just` command runner (v1.41.1) to NanoClaw container image
- Required for ditto backend development using Justfile workflows
- Cross-platform support (amd64/arm64 via musl builds)

## Motivation
The ditto backend repo uses `just` extensively for database migrations, code generation, and development workflows. Agents working on ditto need `just` available in their environment.

## Implementation
- Downloads official musl builds from GitHub releases
- Installs to `/usr/local/bin/just` (available globally)
- Architecture detection handles both amd64 (x86_64) and arm64 (aarch64)

## Changes
- Rebased on main to reduce diff (replaces #31)

## Testing
- [ ] Build container image successfully
- [ ] Verify `just --version` works in container
- [ ] Test with ditto backend Justfile commands

## Related
- Unblocks work on ditto backend migrations and development
- Part of improving NanoClaw's dev tooling support