### PR TITLE
fix: correct just version in Dockerfile

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -26,7 +26,7 @@ ENV GOPATH="/home/bun/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
 # Install just command runner (required for ditto backend development)
-ARG JUST_VERSION=1.41.1
+ARG JUST_VERSION=1.46.0
 RUN ARCH="$(dpkg --print-architecture)" \
     && JUST_ARCH=$([ "$ARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") \
     && wget -q "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \


### PR DESCRIPTION
## Summary

- `just` v1.41.1 was never released, causing container builds to fail with `wget` exit code 8
- Updated to v1.46.0 (latest stable release)

## Test plan

- [x] Container builds successfully with v1.46.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)