### PR TITLE
Fix Discord agent mention parsing to use group-specific agent names

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -234,11 +234,20 @@ export class DiscordChannel implements Channel {
     }
 
     // Translate @bot mention into trigger format
+    // FIX: Determine agent name from the channel's registered group, not global ASSISTANT_NAME
     const botId = this.client.user?.id;
     if (botId && content.includes(`<@${botId}>`)) {
       content = content.replace(new RegExp(`<@${botId}>`, 'g'), '').trim();
       if (!TRIGGER_PATTERN.test(content)) {
-        content = `@${ASSISTANT_NAME} ${content}`;
+        // Get agent name from the group's trigger (e.g., "@OmarOmni" → "OmarOmni")
+        const isDM = message.channel.type === ChannelType.DM;
+        const chatJid = isDM
+          ? `dc:dm:${message.author.id}`
+          : `dc:${message.channelId}`;
+        const registeredGroups = getAllRegisteredGroups();
+        const group = registeredGroups[chatJid];
+        const agentName = group?.trigger?.replace(/^@/, '') || ASSISTANT_NAME;
+        content = `@${agentName} ${content}`;
       }
     }
 


### PR DESCRIPTION
## Problem

All Discord mentions resolved to generic "Omni" instead of agent-specific names (PeytonOmni, OmarOmni, etc.).

## Root Cause

The Discord channel handler runs in the NanoClaw **host process**, not in individual agent containers. The host only has one `ASSISTANT_NAME` environment variable, so all Discord bots shared the same name when translating @mentions.

**Example:**
- Future Trees' host: `ASSISTANT_NAME="Omni"`
- OmarOmni container: `ASSISTANT_NAME="OmarOmni"` ✅
- But `discord.ts` runs in host → uses "Omni" for ALL bots ❌

## Solution

Extract agent name from the registered group's `trigger` field (e.g., `@OmarOmni` → `OmarOmni`) instead of using the global `ASSISTANT_NAME` variable.

**Changed file:** `src/channels/discord.ts`

**Before:**
```typescript
content = `@${ASSISTANT_NAME} ${content}`;  // Always "Omni"
```

**After:**
```typescript
const group = registeredGroups[chatJid];
const agentName = group?.trigger?.replace(/^@/, '') || ASSISTANT_NAME;
content = `@${agentName} ${content}`;  // Uses group-specific name
```

## Impact

- ✅ Each Discord bot now correctly identifies itself using its configured agent name
- ✅ Enables proper multi-agent coordination in Discord channels
- ✅ @PeytonOmni → triggers PeytonOmni (not generic Omni)
- ✅ @OmarOmni → triggers OmarOmni (not generic Omni)

## Testing

Tested with OmarOmni and PeytonOmni in the same Discord channel. Each agent now receives messages with their correct agent name.

## Related

- Quarterplan task: "Fix Discord Agent Mention Parsing"
- Reported by: omarzanji (Discord)
- High priority bug affecting multi-agent coordination

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord bot now correctly uses the appropriate agent name from each channel's registered group when processing @bot mentions. Previously, the bot would always use a single default name across all channels regardless of group configuration. This improves the accuracy of group-based bot interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->