### PR TITLE
Add openssh-client to container for SSH key generation

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     wget \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go (latest stable version) - cross-platform support


### PR DESCRIPTION
## Problem
Agents can't generate SSH keys because `ssh-keygen` is not available in the container. This prevents:
- Generating SSH keys for GitHub authentication
- Cloning private repositories via SSH
- Pushing code changes securely

## Solution
Add `openssh-client` package to the Dockerfile's apt-get install step.

**Includes:**
- `ssh-keygen` - SSH key generation
- `ssh` - SSH client
- `ssh-add` - SSH key management  
- `ssh-agent` - Authentication agent

## Impact
- **Image size**: ~1.5MB additional (openssh-client is lightweight)
- **Security**: No concerns - standard Debian package
- **Compatibility**: Works on all architectures (amd64, arm64)

## Testing
After this PR merges and containers rebuild:
```bash
ssh-keygen -t ed25519 -C "agent@omniaura" -f ~/.ssh/id_ed25519 -N ""
cat ~/.ssh/id_ed25519.pub
```

## Related Work
- Complements existing git + gh CLI setup
- Enables agents to manage their own GitHub authentication
- Unblocks repository access for OmarOmni and other agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image to include SSH client support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->