### PR TITLE
feat: Discord thread streaming + cross-agent thought logs + typing fix

### DIFF
--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -60,6 +60,7 @@ export interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  intermediate?: boolean;
 }
 
 export interface VolumeMount {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,9 @@ export interface Channel {
   disconnect(): Promise<void>;
   // Optional: typing indicator. Channels that support it implement it.
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
+  // Optional: thread support for streaming intermediate output.
+  createThread?(jid: string, messageId: string, name: string): Promise<any>;
+  sendToThread?(thread: any, text: string): Promise<void>;
   // Whether to prefix outbound messages with the assistant name.
   // Telegram bots already display their name, so they return false.
   // WhatsApp returns true. Default true if not implemented.


### PR DESCRIPTION
## Summary
- **Discord threads**: Stream the full agent thought process (thinking, text, tool calls, truncated tool results) to a thread on the user's triggering message in real-time. Final result stays in the main channel.
- **Cross-agent thought logs**: Buffer intermediate output and write as markdown to `groups/global/thoughts/{folder}/` after each query. All agents can read these at `/workspace/global/thoughts/` (already mounted read-only).
- **Typing fix**: Fix hardcoded `whatsapp.setTyping()` to use channel resolution so typing indicators work for Discord and Telegram.

## Files Changed
| File | Change |
|------|--------|
| `src/backends/types.ts` | Add `intermediate?: boolean` to `ContainerOutput` |
| `container/agent-runner/src/index.ts` | Emit thinking, text, tool calls, truncated tool results as intermediate output |
| `src/channels/discord.ts` | Add `createThread()`, `sendToThread()` methods |
| `src/types.ts` | Add optional thread methods to `Channel` interface |
| `src/index.ts` | Thread wiring + thought log writing in `onOutput`, typing fix |

## Test plan
- [ ] Send a complex prompt in Discord — verify thread appears on user's message with thinking, text, tool calls streaming in. Final result in main channel.
- [ ] Send "hi" in Discord — verify no thread, response in main channel only.
- [ ] After a Discord query, check `groups/global/thoughts/{folder}/` for the markdown thought log.
- [ ] Send message from Discord — verify typing indicator works (was broken before).
- [ ] WhatsApp test — verify no behavior change, but thought log is still written.
- [ ] Container rebuild required (`./container/build.sh`) since agent-runner changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent intermediate results now stream to Discord threads, enabling real-time visibility into reasoning steps
  * Automated thought logs saved with timestamp-based filenames for conversation tracking and debugging
  * Discord channel threading support for organizing multi-step agent responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->