### PR TITLE
fix: resolve container OOM hangs from tsgo and --memory flag

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -9,8 +9,10 @@ export NODE_OPTIONS="--max-old-space-size=2048"
 
 # Cap Go heap for tsgo (TypeScript native compiler) — Go doesn't auto-detect
 # container memory limits, so without this tsgo allocates unbounded memory and hangs.
+# Set to 75% of available RAM, leaving headroom for OS + other processes.
 # See: https://github.com/microsoft/typescript-go/issues/2125
-export GOMEMLIMIT=3GiB
+TOTAL_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+export GOMEMLIMIT=$(( TOTAL_KB * 3 / 4 / 1024 ))MiB
 
 # Configure git with GitHub token
 if [ -n "$GITHUB_TOKEN" ]; then

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import {
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
+  CONTAINER_MEMORY,
   CONTAINER_STARTUP_TIMEOUT,
   CONTAINER_TIMEOUT,
   DATA_DIR,
@@ -231,7 +232,7 @@ function buildVolumeMounts(
 }
 
 function buildContainerArgs(mounts: VolumeMount[], containerName: string): string[] {
-  const args: string[] = ['run', '-i', '--rm', '--memory', '4G', '--name', containerName];
+  const args: string[] = ['run', '-i', '--rm', '--memory', CONTAINER_MEMORY, '--name', containerName];
 
   for (const mount of mounts) {
     if (mount.readonly) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export const MAIN_GROUP_FOLDER = 'main';
 
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
+export const CONTAINER_MEMORY = process.env.CONTAINER_MEMORY || '4G';
 export const CONTAINER_TIMEOUT = parseInt(
   process.env.CONTAINER_TIMEOUT || '1800000',
   10,


### PR DESCRIPTION
## Summary

- **Bump container memory to 4 GB** — Apple Container's `--memory` flag treats bare numbers as bytes (not MB), so `--memory 1024` meant 1024 *bytes*, silently hanging the VM. Use `--memory 4G` with proper suffix. Ref: [apple/container#1202](https://github.com/apple/container/issues/1202), [apple/container#1208](https://github.com/apple/container/pull/1208)
- **Set `GOMEMLIMIT=3GiB` in entrypoint** — tsgo (TypeScript native compiler) has no default memory ceiling. Go doesn't auto-detect container/cgroup memory limits, so tsgo allocates unbounded memory until the VM hangs. Ref: [microsoft/typescript-go#2125](https://github.com/microsoft/typescript-go/issues/2125)

## Test plan

- [ ] Verify containers start with 4 GB memory shown in `container list`
- [ ] Run `bun typecheck` (tsgo) on a medium-sized TypeScript project inside a container — should complete without OOM
- [ ] Verify `GOMEMLIMIT` is set: `container run -i --rm --entrypoint /bin/sh nanoclaw-agent:latest -c 'echo $GOMEMLIMIT'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added container memory limits (default 4G) to better control resource usage and improve stability.
  * Set Go runtime heap cap for background processes to ~75% of system memory to reduce out-of-memory risk and smooth performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->