### PR TITLE
fix: add missing SDK tools to agent allowedTools

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -564,6 +564,8 @@ async function runQuery(
         'TeamCreate', 'TeamDelete', 'SendMessage',
         'TodoWrite', 'ToolSearch', 'Skill',
         'NotebookEdit',
+        'EnterPlanMode', 'ExitPlanMode',
+        'TaskCreate', 'TaskGet', 'TaskUpdate', 'TaskList',
         'mcp__nanoclaw__*'
       ],
       env: sdkEnv,


### PR DESCRIPTION
## Summary

- `EnterPlanMode`/`ExitPlanMode` and `TaskCreate`/`TaskGet`/`TaskUpdate`/`TaskList` were missing from the `allowedTools` whitelist in the agent runner
- This caused `ExitPlanMode` to fail silently, leaving agents permanently stuck in plan mode with no way to recover — even after user approval via Discord reaction (👍)
- The agent called `ExitPlanMode` 3 times, all failed, then the session persisted plan mode state across resumes

## Test plan

- [ ] Trigger plan mode in a Discord agent (ask it to plan a complex task)
- [ ] Verify `ExitPlanMode` succeeds and the agent proceeds to implementation
- [ ] Verify `TaskCreate`/`TaskList` work inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled additional task and planning capabilities within the agent, including tools for entering and exiting plan mode, creating tasks, retrieving task information, updating tasks, and listing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->