### PR TITLE
fix: Enable CGO for go-libsql dependency

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     jq \
     ripgrep \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yq (YAML processor, like jq for YAML)
@@ -32,6 +33,7 @@ RUN ARCH="$(dpkg --print-architecture)" \
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/home/bun/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
+ENV CGO_ENABLED=1
 
 # Install just command runner (required for ditto backend development)
 ARG JUST_VERSION=1.46.0


### PR DESCRIPTION
## Problem

Building the Ditto backend in NanoClaw containers failed with:
```
github.com/tursodatabase/go-libsql: build constraints exclude all Go files in /home/bun/go/pkg/mod/github.com/tursodatabase/go-libsql@v0.0.0-20251025125656-00da49cd4a6e
```

This prevented agents from verifying backend compilation, forcing reliance on `go fmt` for syntax checking only.

## Root Cause

The `go-libsql` package requires CGO because it uses C bindings to the native libsql library. The package has:
- Build constraint: `//go:build cgo`
- Platform-specific C library paths (supports linux/arm64)
- Requires a C compiler and build tools

Without CGO enabled, the Go compiler excludes all files from the package, causing the build to fail.

## Solution

This PR makes two changes to the Dockerfile:

1. *Added `build-essential` package* - Provides GCC, make, and other essential build tools needed for CGO compilation
2. *Set `CGO_ENABLED=1` environment variable* - Enables CGO support for all Go builds in the container

## Testing

Verified the fix by successfully building the Ditto backend:
```bash
CGO_ENABLED=1 go build -o /dev/null ./...
```

Build now completes successfully with all dependencies, including go-libsql.

## Impact

- ✅ Agents can now properly compile Go projects that depend on go-libsql
- ✅ Enables full build verification for backend PRs
- ✅ Supports any other CGO-dependent Go packages
- ✅ No performance impact on non-CGO builds

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration and system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->