### PR TITLE
fix: Scheduled task mounts + configurable intermediate streaming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -389,8 +389,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       // Always buffer for thought log
       thoughtLogBuffer.push(raw);
 
-      // Stream to Discord thread if channel supports threads
-      if (channel?.createThread && channel?.sendToThread && triggeringMessageId) {
+      // Stream to channel thread if enabled and supported (off by default)
+      if (group.streamIntermediates && channel?.createThread && channel?.sendToThread && triggeringMessageId) {
         if (!threadCreationAttempted) {
           threadCreationAttempted = true;
           try {

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -270,6 +270,10 @@ async function runTask(
       },
       (proc, containerName) => deps.onProcess(task.chat_jid, proc, containerName, task.group_folder, 'task'),
       async (streamedOutput: ContainerOutput) => {
+        // Skip intermediate output (thinking, tool calls, tool results) —
+        // only forward final results to the channel
+        if (streamedOutput.intermediate) return;
+
         if (streamedOutput.result) {
           result = streamedOutput.result;
           // Forward result to user (sendMessage handles formatting)

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface RegisteredGroup {
   backend?: BackendType;     // Which backend runs this group's agent (default: apple-container)
   description?: string;      // What this agent does (for agent registry)
   devUrl?: string;           // Sprites dev URL (auto-populated for sprites backend)
+  streamIntermediates?: boolean; // Stream intermediate output (thinking, tool calls) to channel threads. Default: false
 }
 
 export interface NewMessage {


### PR DESCRIPTION
## Summary

- **Fix scheduled task container failures**: Apple Container doesn't support file-level bind mounts — only directories. The task mount logic was trying to individually mount `agent_registry.json`, `tasks.json`, and `groups.json` as files, causing every scheduled task to fail with `invalidArgument: "path '...agent_registry.json' is not a directory"`. All 17 active tasks across main, ditto-discord, and local-omni were broken.
- **Make intermediate streaming configurable**: Adds a per-group `stream_intermediates` flag (default: off). Intermediate output (thinking, tool calls, tool results) is only streamed to channel threads when explicitly enabled. Previously any channel with thread support would receive intermediates.

## Changes

| File | Change |
|------|--------|
| `src/backends/local-backend.ts` | Mount full IPC dir + override input/ subdirectory for tasks (instead of individual file mounts) |
| `src/db.ts` | Add `stream_intermediates` column migration + read/write support |
| `src/types.ts` | Add `streamIntermediates` to `RegisteredGroup` interface |
| `src/index.ts` | Gate intermediate thread streaming on `group.streamIntermediates` |

## Test plan

- [x] Verified overlapping bind mounts work in Apple Container (parent dir + subdirectory override)
- [x] Built and deployed — scheduled tasks now execute successfully
- [x] Confirmed intermediate streaming is off for WhatsApp/Telegram, on for Discord groups via DB flag
- [x] Service restarts cleanly with new migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-group setting to opt in to streaming intermediate outputs into Discord threads.

* **Bug Fixes / Behavior Changes**
  * Intermediate "thinking"/tool outputs are no longer forwarded; only final results are delivered.
  * Thread streaming now requires the new per-group opt-in.

* **Chores**
  * Database schema updated to persist the new per-group streaming setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->