### PR TITLE
feat: Stream scheduled task intermediates to Discord threads

### DIFF
--- a/src/thread-streaming.ts
+++ b/src/thread-streaming.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from './config.js';
+import { logger } from './logger.js';
+import type { Channel } from './types.js';
+
+export interface ThreadStreamContext {
+  channel: Channel | undefined;
+  chatJid: string;
+  streamIntermediates: boolean;
+  groupName: string;
+  groupFolder: string;
+  label: string; // for thought log filename slug
+}
+
+export interface ThreadStreamer {
+  handleIntermediate(raw: string): Promise<void>;
+  writeThoughtLog(): void;
+}
+
+/**
+ * Create a ThreadStreamer that buffers intermediate output to a thought log
+ * and optionally streams it to a channel thread (e.g. Discord).
+ *
+ * Graceful degradation: if thread creation fails, intermediates are still
+ * captured in the thought log. No errors are thrown to the caller.
+ */
+export function createThreadStreamer(
+  ctx: ThreadStreamContext,
+  parentMessageId: string | null,
+  threadName: string,
+): ThreadStreamer {
+  const thoughtLogBuffer: string[] = [];
+  let thread: any = null;
+  let threadCreationAttempted = false;
+
+  const canStream =
+    ctx.streamIntermediates &&
+    !!ctx.channel?.createThread &&
+    !!ctx.channel?.sendToThread &&
+    !!parentMessageId;
+
+  return {
+    async handleIntermediate(raw: string): Promise<void> {
+      thoughtLogBuffer.push(raw);
+
+      if (!canStream) return;
+
+      if (!threadCreationAttempted) {
+        threadCreationAttempted = true;
+        try {
+          thread = await ctx.channel!.createThread!(ctx.chatJid, parentMessageId!, threadName);
+        } catch {
+          // Thread creation failed — silently degrade to thought-log only
+        }
+      }
+
+      if (thread) {
+        try {
+          await ctx.channel!.sendToThread!(thread, raw);
+        } catch {
+          // Send failed — continue without thread output
+        }
+      }
+    },
+
+    writeThoughtLog(): void {
+      if (thoughtLogBuffer.length === 0) return;
+
+      try {
+        const now = new Date();
+        const date = now.toISOString().split('T')[0];
+        const time = now.toISOString().split('T')[1].slice(0, 5).replace(':', '');
+        const slug =
+          ctx.label
+            .trim()
+            .slice(0, 50)
+            .replace(/[^a-z0-9]+/gi, '-')
+            .toLowerCase() || 'query';
+        const filename = `${date}-${time}-${slug}.md`;
+        const dir = path.join(GROUPS_DIR, 'global', 'thoughts', ctx.groupFolder);
+        fs.mkdirSync(dir, { recursive: true });
+        const header = `# ${ctx.groupName} — ${now.toLocaleString()}\n\n`;
+        fs.writeFileSync(path.join(dir, filename), header + thoughtLogBuffer.join('\n\n---\n\n'));
+        logger.debug({ group: ctx.groupName, filename }, 'Thought log written');
+      } catch (err) {
+        logger.warn({ group: ctx.groupName, err }, 'Failed to write thought log');
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **New `src/thread-streaming.ts`**: Shared `ThreadStreamer` helper that buffers intermediates to thought logs and optionally streams them to Discord threads with graceful degradation
- **Scheduled task streaming**: Non-heartbeat tasks on stream-enabled Discord channels now send an announcement message, create a thread from it, and stream thinking/tool calls there
- **Deduplication**: Replaced ~40 lines of inline thread/thought-log code in `processGroupMessages` with the shared helper (~15 lines)

## Test plan

- [ ] `bun run build` passes (verified)
- [ ] `tsc --noEmit` passes (verified)
- [ ] Trigger a scheduled task on a Discord channel with `stream_intermediates = 1` — announcement + thread + intermediates stream
- [ ] WhatsApp/Telegram tasks still work (no threads, no intermediates sent, thought logs only)
- [ ] Heartbeat tasks don't create announcement or thread
- [ ] Message-triggered path still creates threads from the triggering message as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled tasks now stream intermediate outputs to Discord threads for real-time progress visibility.
  * Task thinking processes are now logged and persisted for each execution.

* **Improvements**
  * Enhanced error handling ensures graceful degradation if thread operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->