### PR TITLE
fix: Await async sendMessage to restore container spawning

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -100,14 +100,17 @@ export class GroupQueue {
   }
 
   enqueueMessageCheck(groupJid: string): void {
-    if (this.shuttingDown) return;
+    if (this.shuttingDown) {
+      logger.info({ groupJid }, 'enqueueMessageCheck: shutting down, skipping');
+      return;
+    }
 
     const state = this.getGroup(groupJid);
 
     // Only check the message lane — task lane is independent
     if (state.messageActive) {
       state.messagePendingMessages = true;
-      logger.debug({ groupJid }, 'Message container active, message queued');
+      logger.info({ groupJid }, 'Message container active, message queued');
       return;
     }
 
@@ -116,13 +119,14 @@ export class GroupQueue {
       if (!this.waitingMessageGroups.includes(groupJid)) {
         this.waitingMessageGroups.push(groupJid);
       }
-      logger.debug(
+      logger.info(
         { groupJid, activeCount: this.activeCount },
         'At concurrency limit, message queued',
       );
       return;
     }
 
+    logger.info({ groupJid, activeCount: this.activeCount }, 'Launching container for group');
     this.runForGroup(groupJid, 'messages');
   }
 


### PR DESCRIPTION
## Summary

- **Critical bug fix**: PR #63 changed `GroupQueue.sendMessage()` from sync (`boolean`) to async (`Promise<boolean>`), but callers in `index.ts` were never updated to `await` it. Since `if (promise)` is always truthy in JS, the message loop always took the "piped to active container" branch and **never** called `enqueueMessageCheck()` — no new containers were spawned for any channel.
- **Reaction handler fix**: Same issue in `onReaction` callback — `!promise` is always `false`, so reactions never queued containers either. Made the callback `async` to support the `await`.
- **Better observability**: Upgraded `enqueueMessageCheck` logging from `debug` to `info` level so container lifecycle decisions (launching, queuing, concurrency limits) are visible in production logs.

## Test plan

- [x] Built and deployed to production
- [x] Sent test message in Discord — container launched and streamed response
- [x] Verified new logging: `No active container, enqueuing for new one` → `Launching container for group` → `Spawning container agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Discord reaction handling with enhanced error recovery and fallback mechanisms.
  * Added more detailed logging for message processing and queue management to aid in troubleshooting.
  * Enhanced async message delivery with proper result handling for better error resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->