### PR TITLE
fix: Discord replies to bot messages now trigger agent response

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -344,9 +344,10 @@ export class DiscordChannel implements Channel {
     if (message.author.bot && !TRIGGER_PATTERN.test(content)) return;
 
     const isDM = message.channel.type === ChannelType.DM;
-    // In guild channels, only process messages that mention THIS bot. Prevents responding
-    // when another agent (e.g. @PeytonOmni) is mentioned instead.
-    if (!isDM && botId && !message.mentions.users.has(botId)) return;
+    // In guild channels, only process messages that mention THIS bot OR reply to the bot.
+    // Prevents responding when another agent (e.g. @PeytonOmni) is mentioned instead.
+    const isReplyToBot = message.mentions.repliedUser?.id === botId;
+    if (!isDM && botId && !message.mentions.users.has(botId) && !isReplyToBot) return;
 
     const chatJid = isDM
       ? `dc:dm:${message.author.id}`


### PR DESCRIPTION
## Summary

Fixes #76

Users can now reply to bot messages in Discord guilds and get a response, without needing to explicitly @mention the bot.

## Changes

- Add  check using 
- Expand the guild message guard to allow both @mentions AND replies
- Uses efficient Discord.js API (no message fetch required)
- Preserves filter to ignore messages targeting other bots

## Before / After

**Before**: Replying to bot messages in guilds was silently ignored due to the mention filter introduced in fe6029b

**After**: Replies to bot messages trigger agent response, matching natural user expectations

## Implementation

```typescript
const isReplyToBot = message.mentions.repliedUser?.id === botId;
if (!isDM && botId && !message.mentions.users.has(botId) && !isReplyToBot) return;
```

Uses `message.mentions.repliedUser` which is:
- ✅ Efficient (no message fetch needed)
- ✅ Cached by Discord.js automatically
- ✅ Available immediately in the message object

## Testing

Manual testing recommended:
1. Send a message as the bot in a Discord guild channel
2. Reply to that message without @mentioning the bot
3. Verify bot responds to the reply

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bot now responds to direct replies in Discord guild channels, in addition to explicit mentions. This allows for more natural conversational interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->