### PR TITLE
Add unmount-workspaces and disable-project-access Justfile commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -116,18 +116,21 @@ unmount-workspaces group="main":
 # Usage: just enable-project-access [group_folder]  (default: main)
 enable-project-access group="main":
     #!/usr/bin/env bash
+    set -e
     DB="store/messages.db"
     if [ ! -f "$DB" ]; then
         echo "Database not found at $DB"
         exit 1
     fi
+    # Escape single quotes for SQL safety
+    ESCAPED_GROUP=$(echo "{{group}}" | sed "s/'/''/g")
     ROWS=$(sqlite3 "$DB" "
     UPDATE registered_groups
     SET container_config = json_set(
         COALESCE(container_config, '{}'),
         '$.projectAccess', 1
     )
-    WHERE folder = '{{group}}';
+    WHERE folder = '$ESCAPED_GROUP';
     SELECT changes();
     ")
     if [ "$ROWS" -gt 0 ]; then
@@ -141,18 +144,21 @@ enable-project-access group="main":
 # Usage: just enable-ditto-mcp [group_folder]  (default: main)
 enable-ditto-mcp group="main":
     #!/usr/bin/env bash
+    set -e
     DB="store/messages.db"
     if [ ! -f "$DB" ]; then
         echo "Database not found at $DB"
         exit 1
     fi
+    # Escape single quotes for SQL safety
+    ESCAPED_GROUP=$(echo "{{group}}" | sed "s/'/''/g")
     sqlite3 "$DB" "
     UPDATE registered_groups
     SET container_config = json_set(
         COALESCE(container_config, '{}'),
         '$.dittoMcpEnabled', 1
     )
-    WHERE folder = '{{group}}';
+    WHERE folder = '$ESCAPED_GROUP';
     "
     ROWS=$(sqlite3 "$DB" "SELECT changes();")
     if [ "$ROWS" -gt 0 ]; then


### PR DESCRIPTION
Adds two new Justfile commands for unmounting workspaces:

**`just unmount-workspaces [group]`**
- Removes `additionalMounts` from a group's `container_config` in the database
- Host paths like `~/code/ditto-app` are no longer mounted at `/workspace/extra/*`
- Agents can clone their own repos instead

**`just disable-project-access [group]`**
- Removes `projectAccess` from a group's `container_config`
- Unmounts `/workspace/project` (nanoclaw project root) for non-main groups

Usage:
```bash
just unmount-workspaces main        # default group
just unmount-workspaces dm-omar
just disable-project-access ditto-discord
just restart
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands: disable-project-access, unmount-workspaces, enable-project-access, enable-ditto-mcp (group default: main).
  * New commands prompt for a restart on successful changes.

* **Bug Fixes / Reliability**
  * Commands validate database and group presence, exit early on errors, and return clear success/error messages.
  * Scripts now fail fast on errors.

* **Security**
  * Improved escaping/handling of group identifiers to prevent injection and ensure correct matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->