### PR TITLE
feat: Reply context — inbound + outbound for all channels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       if (text && channel) {
         const formatted = formatOutbound(channel, text);
         if (formatted) {
-          await channel.sendMessage(chatJid, formatted);
+          await channel.sendMessage(chatJid, formatted, triggeringMessageId || undefined);
           outputSentToUser = true;
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,7 +113,7 @@ export interface TaskRunLog {
 export interface Channel {
   name: string;
   connect(): Promise<void>;
-  sendMessage(jid: string, text: string): Promise<string | void>;
+  sendMessage(jid: string, text: string, replyToMessageId?: string): Promise<string | void>;
   isConnected(): boolean;
   ownsJid(jid: string): boolean;
   disconnect(): Promise<void>;


### PR DESCRIPTION
## Summary

Closes #81

- **Inbound**: When a user replies to a message, the agent now sees `[Replying to Author: "quoted text"]` prepended to the content — across Discord, WhatsApp, and Telegram
- **Outbound**: Bot responses are sent as native platform replies to the triggering message, visually linking the conversation thread
- Non-reply call sites (scheduled tasks, IPC, cross-agent messages) are unaffected — they continue sending regular messages

## Test plan

- [x] **Discord inbound**: Reply to a message → stored content includes `[Replying to ...]`
- [x] **Discord outbound**: @mention bot → bot's response is a Discord reply to your message
- [ ] **WhatsApp inbound**: Reply to a message → stored content includes `[Replying to ...]`
- [ ] **WhatsApp outbound**: @mention bot → bot's response quotes your message
- [ ] **Telegram inbound**: Reply to a message → stored content includes `[Replying to ...]`
- [ ] **Telegram outbound**: @mention bot → bot's response is a Telegram reply
- [ ] **No regression**: Scheduled tasks, IPC messages still send as regular messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message reply functionality is now available across Discord, Telegram, and WhatsApp channels. Reply to any message to create a reference with full context, including the original sender name and a truncated preview of the referenced message. Responses automatically thread to the triggering message for better conversation organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->