### PR TITLE
Add GitHub skill with Discussions CLI scripts

### DIFF
--- a/.claude/skills/github/README.md
+++ b/.claude/skills/github/README.md
@@ -1,0 +1,26 @@
+# GitHub Skill
+
+Comprehensive GitHub workflow automation for NanoClaw agents.
+
+See [SKILL.md](./SKILL.md) for full documentation.
+
+## Quick Start
+
+```bash
+# List discussions
+./gh-discussion-list omniaura/quarterplan-dashboard
+
+# Create discussion
+./gh-discussion-create omniaura/quarterplan-dashboard "Ideas" "Title" "Body"
+
+# Add comment
+./gh-discussion-comment omniaura/quarterplan-dashboard 42 "Comment text"
+
+# View discussion
+./gh-discussion-view omniaura/quarterplan-dashboard 42
+```
+
+## Requirements
+
+- `gh` (GitHub CLI) - authenticated
+- `jq` (JSON processor)

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -1,0 +1,252 @@
+# GitHub Integration Skill
+
+This skill provides comprehensive GitHub workflow automation using the `gh` CLI and GraphQL API.
+
+## What This Skill Does
+
+- **GitHub Discussions Management**:
+  - List discussions with filtering
+  - Create new discussions in any category
+  - Add comments to discussions
+  - View discussions with full comment threads
+- **Future**: PR management, issue triage, project boards, CI/CD workflows
+
+## Usage
+
+All GitHub operations are handled through executable bash scripts:
+
+### GitHub Discussions
+
+```bash
+# List discussions (default: 20 most recent)
+./gh-discussion-list [owner/repo] [limit]
+./gh-discussion-list omniaura/quarterplan-dashboard
+./gh-discussion-list ditto-assistant/ditto-app 50
+
+# Create a new discussion
+./gh-discussion-create [owner/repo] [category] [title] [body]
+./gh-discussion-create omniaura/quarterplan-dashboard "Ideas" "Feature Request" "Description..."
+
+# Add comment to discussion
+./gh-discussion-comment [owner/repo] [discussion-number] [comment-body]
+./gh-discussion-comment omniaura/quarterplan-dashboard 42 "Progress update..."
+
+# View discussion with all comments
+./gh-discussion-view [owner/repo] [discussion-number]
+./gh-discussion-view omniaura/quarterplan-dashboard 42
+```
+
+### Available Discussion Categories
+
+- `Announcements` 📣 - Updates from maintainers
+- `General` 💬 - Chat about anything
+- `Ideas` 💡 - Share ideas for new features
+- `Polls` 🗳️ - Take a vote from the community
+- `Q&A` 🙏 - Ask the community for help
+- `Show and tell` 🙌 - Show off something you've made
+
+## Setup
+
+### Prerequisites
+
+1. **GitHub CLI** (`gh`):
+   ```bash
+   # macOS
+   brew install gh
+
+   # Linux
+   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+   sudo apt update
+   sudo apt install gh
+   ```
+
+2. **jq** (JSON processor):
+   ```bash
+   # macOS
+   brew install jq
+
+   # Linux
+   sudo apt install jq
+   ```
+
+3. **Authentication**:
+   ```bash
+   gh auth login
+   # Follow prompts to authenticate with GitHub
+   ```
+
+### Add to PATH (Optional)
+
+For system-wide access:
+
+```bash
+export PATH="$PATH:$(pwd)/.claude/skills/github"
+```
+
+## Integration with NanoClaw
+
+This skill can be invoked from NanoClaw agents to:
+
+- **Quarterly Planning**: Create planning threads for each quarter
+- **Progress Tracking**: Post weekly updates to ongoing discussions
+- **Feature Brainstorming**: Create "Ideas" discussions for feature proposals
+- **Retrospectives**: Create "General" discussions for post-mortems
+- **Agent Coordination**: Use discussions as shared context between agents
+
+### Example Agent Usage
+
+```typescript
+import { $ } from 'bun';
+
+// Create quarterly planning discussion
+const result = await $`
+  .claude/skills/github/gh-discussion-create
+  omniaura/quarterplan-dashboard
+  "Announcements"
+  "Q1 2026 Planning"
+  "Our focus areas for Q1 2026..."
+`.text();
+
+console.log(result); // "Created discussion #42: Q1 2026 Planning"
+
+// Post weekly progress update
+await $`
+  .claude/skills/github/gh-discussion-comment
+  omniaura/quarterplan-dashboard
+  42
+  "Week 3 Update: Completed 15/20 tasks, on track for Q1 goals"
+`.text();
+```
+
+## Use Cases
+
+### 1. Quarterly Planning Automation
+
+Create quarterly planning discussions at the start of each quarter:
+
+```bash
+gh-discussion-create omniaura/quarterplan-dashboard "Announcements" \
+  "Q1 2026 Planning" "Our focus areas for Q1: 1) Mac Runner stability, 2) Ditto MCP improvements, 3) NanoClaw agent coordination"
+```
+
+### 2. Feature Proposal Workflow
+
+Agents can autonomously create feature discussions:
+
+```bash
+gh-discussion-create ditto-assistant/ditto-app "Ideas" \
+  "Drag-and-Drop File Upload" "Proposal to add drag-and-drop file upload to chat interface"
+```
+
+### 3. Retrospectives & Post-Mortems
+
+Create retrospective threads after major milestones:
+
+```bash
+gh-discussion-create omniaura/mac-runner "General" \
+  "Phase 6 Retrospective" "What went well: hybrid isolation strategy. What to improve: Mac hardware testing coverage."
+```
+
+### 4. Agent Coordination via Discussions
+
+Agents can use discussions as shared context:
+
+```bash
+# Agent 1 creates discussion with findings
+gh-discussion-create omniaura/nanoclaw "Q&A" \
+  "Cloud-Local Communication Strategy" "Researched Sprites ↔ Apple Container communication patterns..."
+
+# Agent 2 adds insights to same discussion
+gh-discussion-comment omniaura/nanoclaw 15 \
+  "Found IPC file-based messaging system in src/ipc/. This could be extended for cloud-local comms."
+```
+
+## Architecture
+
+- ✅ **No NanoClaw core modifications** - Standalone bash scripts
+- ✅ **CLI-first design** - Easy to test and invoke
+- ✅ **GraphQL API** - Direct GitHub API access via `gh api graphql`
+- ✅ **Human-readable output** - Formatted with `jq` and `column`
+- ✅ **Error handling** - Validation and helpful error messages
+- ✅ **Flexible defaults** - Works with any repo, defaults to `omniaura/quarterplan-dashboard`
+
+## Files
+
+- `SKILL.md` - This documentation
+- `gh-discussion-list` - List discussions with filtering
+- `gh-discussion-create` - Create new discussions
+- `gh-discussion-comment` - Add comments to discussions
+- `gh-discussion-view` - View full discussion threads
+
+## Development Patterns & Best Practices
+
+### Why GitHub Discussions Over Custom Tools?
+
+GitHub Discussions provides:
+- **Native integration** with GitHub Issues, PRs, and code
+- **Rich formatting** with Markdown support
+- **Notification system** built into GitHub
+- **Discoverability** - all conversations in one place
+- **Searchable history** - never lose context
+- **Upvoting/reactions** - community feedback built-in
+
+For agent coordination, Discussions are superior to Slack/Discord because:
+- **Persistent context** - doesn't scroll away like chat
+- **Threaded conversations** - organized by topic
+- **Linked to code** - reference commits, PRs, issues directly
+- **GitHub-native** - no additional tools to maintain
+
+### Agent Coordination Strategies
+
+1. **Use "Announcements" for milestones**: Quarterly goals, major releases
+2. **Use "Ideas" for feature proposals**: Agents can propose features autonomously
+3. **Use "General" for retrospectives**: Post-mortems and learning notes
+4. **Use "Q&A" for technical questions**: Agents can ask other agents for help
+5. **Cross-reference with Issues/PRs**: Link discussions to specific work items
+
+### Gotchas & Best Practices
+
+- **Authentication**: Ensure `gh auth login` is completed before using scripts
+- **Rate Limits**: GitHub GraphQL API has rate limits (5000 requests/hour for authenticated users)
+- **Category IDs**: Categories are repo-specific. Scripts handle common categories, but custom categories need GraphQL queries
+- **Markdown Formatting**: Use proper escaping for multiline bodies (use `\n` or heredocs)
+- **Default Repo**: Scripts default to `omniaura/quarterplan-dashboard` - override with `owner/repo` argument
+
+### Common Workflows
+
+**Weekly Progress Updates**:
+```bash
+# Create quarterly planning discussion once
+DISCUSSION_ID=$(gh-discussion-create omniaura/quarterplan-dashboard "Announcements" "Q1 2026" "Goals..." | grep -oP '#\K\d+')
+
+# Add weekly updates as comments
+gh-discussion-comment omniaura/quarterplan-dashboard $DISCUSSION_ID "Week 1: Completed Mac Runner Phase 6"
+gh-discussion-comment omniaura/quarterplan-dashboard $DISCUSSION_ID "Week 2: NanoClaw stability audit"
+```
+
+**Feature Brainstorming**:
+```bash
+# Agent 1: Propose feature
+DISCUSSION_ID=$(gh-discussion-create ditto-assistant/ditto-app "Ideas" "Dark Mode" "..." | grep -oP '#\K\d+')
+
+# Agent 2: Add design notes
+gh-discussion-comment ditto-assistant/ditto-app $DISCUSSION_ID "Design consideration: sync with system theme"
+
+# Agent 3: Add implementation notes
+gh-discussion-comment ditto-assistant/ditto-app $DISCUSSION_ID "Can use CSS variables + prefers-color-scheme"
+```
+
+## Future Enhancements
+
+- [ ] Add `gh-discussion-update` for editing discussion title/body
+- [ ] Add `gh-discussion-close` for closing discussions
+- [ ] Add `gh-discussion-lock` for locking discussions
+- [ ] Add filtering by category, author, date range
+- [ ] Add search functionality across discussions
+- [ ] Add upvote/downvote commands
+- [ ] PR management scripts (`gh-pr-create`, `gh-pr-review`, `gh-pr-merge`)
+- [ ] Issue triage scripts (`gh-issue-label`, `gh-issue-assign`)
+- [ ] GitHub Projects/Kanban integration
+- [ ] CI/CD workflow management (trigger workflows, check status)
+- [ ] Automated quarterly planning thread creation (scheduled task)

--- a/.claude/skills/github/gh-discussion-comment
+++ b/.claude/skills/github/gh-discussion-comment
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Add a comment to a GitHub Discussion
+# Usage: gh-discussion-comment [owner/repo] [discussion-number] [comment-body]
+
+set -euo pipefail
+
+REPO="${1:-omniaura/quarterplan-dashboard}"
+DISCUSSION_NUM="${2:-}"
+COMMENT="${3:-}"
+
+if [[ -z "$DISCUSSION_NUM" ]] || [[ -z "$COMMENT" ]]; then
+  echo "Error: Discussion number and comment body are required" >&2
+  echo "Usage: gh-discussion-comment [owner/repo] [discussion-number] [comment-body]" >&2
+  exit 1
+fi
+
+IFS='/' read -r OWNER REPO_NAME <<< "$REPO"
+
+# Get discussion ID
+DISCUSSION_ID=$(gh api graphql -f query="
+query {
+  repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    discussion(number: $DISCUSSION_NUM) {
+      id
+    }
+  }
+}
+" | jq -r '.data.repository.discussion.id')
+
+if [[ -z "$DISCUSSION_ID" || "$DISCUSSION_ID" == "null" ]]; then
+  echo "Error: Discussion #$DISCUSSION_NUM not found" >&2
+  exit 1
+fi
+
+# Add comment
+RESULT=$(gh api graphql -f query="
+mutation {
+  addDiscussionComment(input: {
+    discussionId: \"$DISCUSSION_ID\"
+    body: \"$COMMENT\"
+  }) {
+    comment {
+      id
+      url
+    }
+  }
+}
+")
+
+echo "$RESULT" | jq -r '.data.addDiscussionComment.comment | "Comment added: \(.url)"'

--- a/.claude/skills/github/gh-discussion-create
+++ b/.claude/skills/github/gh-discussion-create
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Create a GitHub Discussion
+# Usage: gh-discussion-create [owner/repo] [category] [title] [body]
+
+set -euo pipefail
+
+REPO="${1:-omniaura/quarterplan-dashboard}"
+CATEGORY="${2:-General}"
+TITLE="${3:-}"
+BODY="${4:-}"
+
+if [[ -z "$TITLE" ]]; then
+  echo "Error: Title is required" >&2
+  echo "Usage: gh-discussion-create [owner/repo] [category] [title] [body]" >&2
+  exit 1
+fi
+
+IFS='/' read -r OWNER REPO_NAME <<< "$REPO"
+
+# Get repository ID
+REPO_ID=$(gh api graphql -f query="
+query {
+  repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    id
+  }
+}
+" | jq -r '.data.repository.id')
+
+# Get category ID
+CATEGORY_ID=$(gh api graphql -f query="
+query {
+  repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    discussionCategories(first: 20) {
+      nodes {
+        id
+        name
+      }
+    }
+  }
+}
+" | jq -r ".data.repository.discussionCategories.nodes[] | select(.name == \"$CATEGORY\") | .id")
+
+if [[ -z "$CATEGORY_ID" ]]; then
+  echo "Error: Category '$CATEGORY' not found" >&2
+  echo "Available categories:" >&2
+  gh api graphql -f query="
+  query {
+    repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+      discussionCategories(first: 20) {
+        nodes {
+          name
+          emoji
+          description
+        }
+      }
+    }
+  }
+  " | jq -r '.data.repository.discussionCategories.nodes[] | "  \(.emoji) \(.name) - \(.description)"' >&2
+  exit 1
+fi
+
+# Create discussion
+RESULT=$(gh api graphql -f query="
+mutation {
+  createDiscussion(input: {
+    repositoryId: \"$REPO_ID\"
+    categoryId: \"$CATEGORY_ID\"
+    title: \"$TITLE\"
+    body: \"$BODY\"
+  }) {
+    discussion {
+      id
+      number
+      title
+      url
+    }
+  }
+}
+")
+
+echo "$RESULT" | jq -r '.data.createDiscussion.discussion | "Created discussion #\(.number): \(.title)\n\(.url)"'

--- a/.claude/skills/github/gh-discussion-list
+++ b/.claude/skills/github/gh-discussion-list
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# List GitHub Discussions for a repository
+# Usage: gh-discussion-list [owner/repo] [limit]
+
+set -euo pipefail
+
+REPO="${1:-omniaura/quarterplan-dashboard}"
+LIMIT="${2:-20}"
+
+IFS='/' read -r OWNER REPO_NAME <<< "$REPO"
+
+gh api graphql -f query="
+query {
+  repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    discussions(first: $LIMIT, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        author {
+          login
+        }
+        category {
+          name
+          emoji
+        }
+        createdAt
+        updatedAt
+        url
+        comments(first: 0) {
+          totalCount
+        }
+        upvoteCount
+      }
+    }
+  }
+}
+" | jq -r '
+  ["#", "CATEGORY", "TITLE", "AUTHOR", "COMMENTS", "UPVOTES", "CREATED", "URL"],
+  (.data.repository.discussions.nodes[] |
+    [
+      .number,
+      "\(.category.emoji) \(.category.name)",
+      .title,
+      "@\(.author.login)",
+      "\(.comments.totalCount) comments",
+      "\(.upvoteCount) upvotes",
+      .createdAt,
+      .url
+    ]
+  ) |
+  @tsv
+'

--- a/.claude/skills/github/gh-discussion-view
+++ b/.claude/skills/github/gh-discussion-view
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# View a GitHub Discussion with its comments
+# Usage: gh-discussion-view [owner/repo] [discussion-number]
+
+set -euo pipefail
+
+REPO="${1:-omniaura/quarterplan-dashboard}"
+DISCUSSION_NUM="${2:-}"
+
+if [[ -z "$DISCUSSION_NUM" ]]; then
+  echo "Error: Discussion number is required" >&2
+  echo "Usage: gh-discussion-view [owner/repo] [discussion-number]" >&2
+  exit 1
+fi
+
+IFS='/' read -r OWNER REPO_NAME <<< "$REPO"
+
+gh api graphql -f query="
+query {
+  repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    discussion(number: $DISCUSSION_NUM) {
+      number
+      title
+      body
+      author {
+        login
+      }
+      category {
+        name
+        emoji
+      }
+      createdAt
+      updatedAt
+      url
+      upvoteCount
+      comments(first: 50) {
+        totalCount
+        nodes {
+          author {
+            login
+          }
+          body
+          createdAt
+          upvoteCount
+        }
+      }
+    }
+  }
+}
+" | jq -r '
+.data.repository.discussion |
+"# [\(.category.emoji) \(.category.name)] \(.title)
+
+**Author**: @\(.author.login)
+**Created**: \(.createdAt)
+**Updated**: \(.updatedAt)
+**Upvotes**: \(.upvoteCount)
+**URL**: \(.url)
+
+---
+
+\(.body)
+
+---
+
+## Comments (\(.comments.totalCount))
+
+" + (.comments.nodes | map("### @\(.author.login) - \(.createdAt) (\(.upvoteCount) upvotes)\n\n\(.body)\n") | join("\n---\n\n"))
+'


### PR DESCRIPTION
## Summary

Adds comprehensive GitHub workflow automation as a NanoClaw skill, enabling all agents to manage GitHub Discussions programmatically.

## What's Included

**GitHub Discussions Management:**
- `gh-discussion-list` - List discussions with filtering
- `gh-discussion-create` - Create discussions in any category (Announcements, Ideas, General, Q&A, etc.)
- `gh-discussion-comment` - Add comments to discussions
- `gh-discussion-view` - View full discussion threads with comments

## Benefits for Agent Coordination

This skill enables agents to:
- **Automate quarterly planning** - Create planning threads at start of each quarter
- **Feature brainstorming** - Agents can propose features autonomously via "Ideas" discussions
- **Retrospectives** - Create post-mortems after major milestones
- **Persistent context** - Use discussions as shared context between agents (better than chat)
- **GitHub-native collaboration** - All conversations linked to code, issues, PRs

## Architecture

- ✅ **No core modifications** - Standalone bash scripts
- ✅ **CLI-first design** - Easy to test and invoke from agents
- ✅ **GraphQL API** - Direct GitHub API access via `gh` CLI
- ✅ **Comprehensive docs** - SKILL.md includes best practices, gotchas, and development patterns
- ✅ **Error handling** - Validation and helpful error messages

## Example Agent Usage

```bash
# Create quarterly planning discussion
./gh-discussion-create omniaura/quarterplan-dashboard "Announcements" \
  "Q1 2026 Planning" "Our focus areas for Q1: Mac Runner, Ditto MCP, NanoClaw"

# Post weekly progress update
./gh-discussion-comment omniaura/quarterplan-dashboard 42 \
  "Week 3: Completed Mac Runner Phase 6, started NanoClaw stability audit"

# View discussion with all comments
./gh-discussion-view omniaura/quarterplan-dashboard 42
```

## Integration with Agent Workflows

These scripts simplify GitHub coordination across all OmniAura agents:
- PeytonOmni can create planning discussions during heartbeats
- LocalOmni can post progress updates automatically
- All agents can reference discussions for shared context
- Replace custom planning tools with GitHub-native workflows

## Future Enhancements

- PR management (`gh-pr-create`, `gh-pr-review`, `gh-pr-merge`)
- Issue triage (`gh-issue-label`, `gh-issue-assign`)
- GitHub Projects/Kanban integration
- CI/CD workflow management

## Test Plan

```bash
# Test list
./gh-discussion-list omniaura/nanoclaw

# Test create
./gh-discussion-create omniaura/nanoclaw "Ideas" "Test Discussion" "Test body"

# Test comment
./gh-discussion-comment omniaura/nanoclaw 1 "Test comment"

# Test view
./gh-discussion-view omniaura/nanoclaw 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Skill to manage GitHub Discussions: list discussions (TSV output), create discussions with category/title/body validation, post comments, and view full discussion threads with metadata and comment history rendered for reading.

* **Documentation**
  * Added comprehensive docs and a README with quick start, prerequisites, usage examples, workflows, setup/authentication guidance, and best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->