### PR TITLE
Fix: Add 10-minute timeout to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Problem

The Test workflow hangs indefinitely on recent PRs, blocking CI.

Recent examples:
- PR #89: Hung for 1+ hour
- PR #90: Hung for 1+ hour

## Solution

Add `timeout-minutes: 10` to the test job. This ensures:
- Tests fail fast instead of hanging forever
- We can identify which test is problematic
- GitHub Actions minutes aren't wasted

## Related

Fixes #91

## Testing

- [x] Workflow syntax is valid (GitHub checks on push)
- [ ] Will verify timeout works when applied to PRs #89, #90

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test job configuration to support extended runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->