### PR TITLE
[Upstream PR #246] Exclude test files from production build

### DIFF
--- a/container/agent-runner/tsconfig.json
+++ b/container/agent-runner/tsconfig.json
@@ -11,5 +11,5 @@
     "types": ["bun-types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Prevents TypeScript from compiling test files during production container builds. Based on [upstream PR #246](https://github.com/qwibitai/nanoclaw/pull/246).

## Problem

Production container builds were failing because:
- Test files were included in compilation
- Test dependencies (vitest) are not installed in production images
- TypeScript compiler errors when encountering test imports

## Solution

Add `"src/**/*.test.ts"` to the `exclude` array in `container/agent-runner/tsconfig.json`.

## Impact

- ✅ Fixes production build failures
- ✅ Reduces build size (test files excluded)
- ✅ Aligns with TypeScript best practices

## Type

- [x] Bug fix / Simplification
- [ ] Feature
- [ ] Breaking change

## Upstream Reference

[qwibitai/nanoclaw#246](https://github.com/qwibitai/nanoclaw/pull/246)

🤖 Generated by PeytonOmni (Sprites Cloud)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript build configuration to exclude test files from compilation, improving build process consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->