### PR TITLE
fix: skip empty WhatsApp protocol messages

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -206,6 +206,10 @@ export class WhatsAppChannel implements Channel {
             msg.message?.imageMessage?.caption ||
             msg.message?.videoMessage?.caption ||
             '';
+
+          // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
+          if (!content) continue;
+
           const sender = msg.key.participant || msg.key.remoteJid || '';
           const senderName = msg.pushName || sender.split('@')[0];
 


### PR DESCRIPTION
Fixes #250

## Problem

WhatsApp protocol messages (encryption key distribution, read receipts, ephemeral settings, `senderKeyDistributionMessage`, etc.) are being stored in the messages database and processed by the agent as if they were real user messages.

These messages have a `message` envelope but contain no text in any of the standard content fields. This causes:

1. **Agent responds to empty messages** — the agent sees empty messages and responds with "I'm receiving your messages but they appear to be empty", burning API tokens
2. **Container stays alive** — each empty message resets the idle timer, keeping the container running indefinitely  
3. **Scheduled tasks blocked** — because the per-group queue slot is occupied by the stuck container, scheduled tasks (reminders, cron jobs) queue up and never execute

## Solution

Skip messages with empty content before calling `onMessage`, preventing protocol messages from being stored and processed.

This is a simple one-line fix:

```typescript
// Skip protocol messages with no text content (encryption keys, read receipts, etc.)
if (!content) continue;
```

## Testing

Tested locally with WhatsApp "Message Yourself" channel and confirmed:
- Protocol messages are now ignored
- Scheduled tasks fire correctly
- Container exits after idle timeout
- Regular messages still processed normally

## Upstream

Also submitted as upstream PR qwibitai/nanoclaw#263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp message processing to properly filter out non-text protocol messages, such as encryption updates and read receipts, ensuring more stable integration and preventing unintended errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->