### PR TITLE
feat: support CLAUDE_MODEL env var for model selection

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -742,6 +742,8 @@ async function main(): Promise<void> {
     sdkEnv[key] = value;
   }
 
+  log(`Model: ${sdkEnv.CLAUDE_MODEL || '(default)'}`);
+
   const mcpServerPath = path.join(import.meta.dir, 'ipc-mcp-stdio.ts');
 
   let sessionId = containerInput.sessionId;

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -167,7 +167,7 @@ function buildVolumeMounts(
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'GITHUB_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL'];
+    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'GITHUB_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'CLAUDE_MODEL'];
     const filteredLines = envContent.split('\n').filter((line) => {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('#')) return false;


### PR DESCRIPTION
## Summary
- Add `CLAUDE_MODEL` to the allowed env vars passed to container agents, enabling model override via `.env`
- Log the active model on container startup for observability

## Test plan
- [x] Set `CLAUDE_MODEL=claude-opus-4-6` in `.env`, restarted service, confirmed env file includes it
- [x] Verified `[agent-runner] Model: claude-opus-4-6` appears in container logs on message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLAUDE_MODEL environment value is now displayed at application startup for improved visibility.
  * CLAUDE_MODEL environment variable from project configuration is now properly propagated to the runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->