### PR TITLE
fix: Reply to triggering message instead of last message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -421,7 +421,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   // Thread streaming via shared helper
   // Synthetic IDs (synth-*, react-*, notify-*, s3-*) aren't real channel message IDs
   // and will cause Discord/Telegram API failures if passed as reply references.
-  const rawMessageId = missedMessages[missedMessages.length - 1]?.id || null;
+  // Find the first message with a trigger (the one that actually triggered the agent)
+  const triggeringMessage = missedMessages.find((m) => TRIGGER_PATTERN.test(m.content.trim()));
+  const rawMessageId = triggeringMessage?.id || missedMessages[missedMessages.length - 1]?.id || null;
   const triggeringMessageId = rawMessageId && /^(synth|react|notify|s3)-/.test(rawMessageId) ? null : rawMessageId;
   const lastContent = missedMessages[missedMessages.length - 1]?.content || '';
   const threadName = lastContent


### PR DESCRIPTION
## Summary
Fixes #271 - Agent replies now thread to the correct parent message (the one that triggered the agent) instead of always threading to the last message in the batch.

## Problem
When multiple messages arrived before the agent responded, Discord reply threading would show the agent replying to the wrong message - always the chronologically last message rather than the one with the trigger.

## Root Cause
`src/index.ts:424` used `missedMessages[missedMessages.length - 1]` to determine the reply target. This picked the last message in the batch, not the message that contained the trigger pattern.

## Solution
- Find the **first** message matching `TRIGGER_PATTERN` (the actual trigger)
- Use that message's ID as `triggeringMessageId`
- Fallback to last message if no trigger found (DMs/auto-respond)
- Preserves synthetic ID filtering for safety

## Changes
- `src/index.ts:424-426`: Added logic to find first triggering message

## Testing
- [x] Build passes
- [x] Logic preserves existing behavior for single-message cases
- [x] Multi-message scenarios now thread correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message processing logic to better identify and handle group messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->