### PR TITLE
Fix agent name display - use trigger name instead of generic ASSISTANT_NAME

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,5 @@
 import { ASSISTANT_NAME } from './config.js';
-import { Channel, NewMessage } from './types.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
 
 export function escapeXml(s: string): string {
   if (!s) return '';
@@ -21,11 +21,17 @@ export function stripInternalTags(text: string): string {
   return text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
 }
 
-export function formatOutbound(channel: Channel, rawText: string): string {
+export function getAgentName(group: RegisteredGroup): string {
+  // Extract agent name from trigger (e.g., "@OmarOmni" → "OmarOmni")
+  return group.trigger?.replace(/^@/, '') || ASSISTANT_NAME;
+}
+
+export function formatOutbound(channel: Channel, rawText: string, agentName?: string): string {
   const text = stripInternalTags(rawText);
   if (!text) return '';
+  const name = agentName || ASSISTANT_NAME;
   const prefix =
-    channel.prefixAssistantName !== false ? `${ASSISTANT_NAME}: ` : '';
+    channel.prefixAssistantName !== false ? `${name}: ` : '';
   return `${prefix}${text}`;
 }
 


### PR DESCRIPTION
## Problem

All agents appeared as "Omni" instead of their specific names (OmarOmni, NicholasOmni, PeytonOmni) in Discord messages.

## Solution

- Added `getAgentName()` helper that extracts name from trigger (@OmarOmni → OmarOmni)
- Updated `formatOutbound()` to accept optional `agentName` parameter
- Pass agent-specific name in all message formatting calls (processGroupMessages, scheduled tasks, IPC)

## Changes

**router.ts:**
- New `getAgentName(group)` function - extracts agent name from trigger
- `formatOutbound()` now takes optional `agentName` parameter

**index.ts:**
- Import `getAgentName` helper
- Pass agent name in processGroupMessages output
- Pass agent name in scheduled task messages
- Pass agent name in IPC messages

## Testing

- Verify OmarOmni appears as "OmarOmni" not "Omni"
- Verify NicholasOmni appears correctly
- Verify PeytonOmni appears correctly
- Check scheduled messages use correct agent name
- Check IPC messages use correct agent name

## Impact

Agents now show correct identity in Discord responses, improving clarity about which agent is responding.

Fixes kanban initiative: `init-1771098984478-jjkah`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent name attribution in outbound messages across all channels — scheduled, startup, IPC, and normal message paths now include the correct agent identity based on group context, with automatic fallback to the default name when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->