### PR TITLE
fix: skip empty messages from triggering agent responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -368,7 +368,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const missedMessages = getMessagesSince(
     chatJid,
     sinceTimestamp,
-  );
+  ).filter((m) => m.content.trim().length > 0);
 
   if (missedMessages.length === 0) return true;
 


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Non-text WhatsApp messages (reactions, stickers, read receipts, protocol messages)
are stored in the database with empty content. In main group mode, these bypass
the trigger pattern check and spawn agent runs for blank messages.

This PR filters out messages with empty content (after trimming) in `processGroupMessages()`.
Messages are still stored in the database so they appear as context when the agent
runs on a real message.

## Changes

- Filter empty messages in `processGroupMessages()` before processing

## Testing

- Tested with WhatsApp reactions and read receipts
- Confirmed empty messages don't trigger agent runs
- Confirmed messages still appear in database for context

Replaces #121 with updated fix for current main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message processing to skip empty or whitespace-only messages. This prevents blank items from entering message workflows, reducing spurious notifications and improving display and threading consistency so users see only meaningful content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->