### PR TITLE
feat: protect .env secrets from Claude Code ([Upstream PR #288])

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(path:.env.example)"
+    ],
+    "deny": [
+      "Read(path:.env)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ groups/global/*
 .env
 mcp.json
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # SQLite databases
 *.db
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ bun run build        # Compile TypeScript
 ./container/build.sh # Rebuild agent container
 ```
 
+### Environment Variables
+
+- **Never** read or modify `.env` — it contains secrets and is denied in settings.
+- When a new environment variable is needed, add it to `.env.example` with an empty or placeholder value and a descriptive comment.
+- Tell the user to fill in the actual value in `.env`.
+
 Service management:
 ```bash
 launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist


### PR DESCRIPTION
Adopt upstream security improvements to prevent accidental exposure of secrets in Claude Code.

## Changes

- Add `.claude/settings.json` with `Read(path:.env)` denial
- Update `.gitignore` to ignore `.claude/settings.local.json`
- Add environment variable guidance to `CLAUDE.md`

## Impact

Defense-in-depth for secret protection. Complements existing sanitization by:
- Preventing Claude Code from reading `.env` file
- Documenting best practices for environment variables
- Ensuring local settings overrides are not committed

## Upstream

Tracked in `/workspace/group/upstream-tracking-2026-02-18.md`

**Upstream PR:** https://github.com/qwibitai/nanoclaw/pull/288

## Testing

- [x] Verified `.env` is denied in Claude Code settings
- [x] Confirmed `.env.example` is allowed for reference
- [x] Checked `.gitignore` excludes local settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added environment variable configuration guidance, clarifying setup requirements and best practices for .env file handling.

* **Chores**
  * Updated development configuration to streamline local settings management and improve setup consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->