### PR TITLE
feat: suppress system/auth errors from channels ([Upstream PR #298])

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -448,6 +448,21 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     /rate_limit_error/,
   ];
 
+  // Redact sensitive data from error messages before logging
+  function redactSensitiveData(text: string): string {
+    return text
+      // Redact bearer tokens
+      .replace(/Bearer\s+[A-Za-z0-9_\-\.]{20,}/gi, 'Bearer [REDACTED]')
+      // Redact API keys (common patterns: sk-..., key_..., etc.)
+      .replace(/\b(?:sk|key|api)[_-][A-Za-z0-9_\-]{16,}/gi, '[API_KEY_REDACTED]')
+      // Redact long hex strings (likely tokens/secrets)
+      .replace(/\b[a-f0-9]{32,}\b/gi, '[HEX_TOKEN_REDACTED]')
+      // Redact JWT tokens
+      .replace(/eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g, '[JWT_REDACTED]')
+      // Redact common password/secret field values in JSON
+      .replace(/"(?:password|secret|token|apikey)":\s*"[^"]+"/gi, '"$1":"[REDACTED]"');
+  }
+
   // Thread streaming via shared helper
   // Synthetic IDs (synth-*, react-*, notify-*, s3-*) aren't real channel message IDs
   // and will cause Discord/Telegram API failures if passed as reply references.
@@ -493,7 +508,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         // This prevents infinite loops when auth fails (error echoed back → triggers agent → fails again)
         const isSystemError = systemErrorPatterns.some((p) => p.test(text));
         if (isSystemError) {
-          logger.error({ group: group.name }, `Suppressed system error (not sent to user): ${text.slice(0, 300)}`);
+          const redactedText = redactSensitiveData(text.slice(0, 300));
+          logger.error({ group: group.name }, `Suppressed system error (not sent to user): ${redactedText}`);
           hadError = true;
           // Skip sending to channel but continue processing
         } else if (text && channel) {


### PR DESCRIPTION
## Summary

Prevent infinite loops when Claude API authentication fails.

Adopts [Upstream PR #298](https://github.com/qwibitai/nanoclaw/pull/298) with adaptation for our channel abstraction.

## Problem

When auth fails (invalid token, rate limit), the agent outputs the error as a "success" result. The streaming callback forwards it to WhatsApp/Discord, which echoes it back, triggering the agent again → **infinite loop**.

Example flow:
1. Invalid API token → Claude API returns 401/auth error
2. Agent-runner outputs error as "success" result  
3. Streaming callback sends error to WhatsApp
4. WhatsApp echoes error back as new message
5. Triggers agent again → repeats indefinitely

**Impact:** Spams users, wastes API credits, prevents legitimate work.

## Solution

Add regex pattern matching to detect system/auth errors and suppress them from being sent to channels:

```typescript
const systemErrorPatterns = [
  /^Failed to authenticate\b/,
  /^API Error: \d{3}\b/,
  /authentication_error/,
  /Invalid (?:API key|bearer token)/,
  /rate_limit_error/,
];
```

Errors are:
- ✅ Still logged to `logs/nanoclaw.log` for debugging
- ❌ NOT sent to channels (prevents feedback loop)
- ✅ Tracked via `hadError` flag for retry logic

## Changes

- Add `systemErrorPatterns` array in `processGroupMessages`
- Check text against patterns before sending to channel
- Log suppressed errors with ERROR level for debugging
- Set `hadError = true` to track error state
- Adapted for our channel abstraction (works with WhatsApp, Discord, Telegram, Slack)

## Upstream Differences

**Upstream PR #298:**
- WhatsApp-specific (`whatsapp.sendMessage`)
- Checks patterns in WhatsApp callback

**Our Implementation:**
- Channel-agnostic (works with all platforms)
- Checks patterns in streaming callback before `channel.sendMessage`
- Integrates with our `formatOutbound` system

## Impact

**Defense-in-depth** for error handling:
- ✅ Prevents infinite loops from auth failures
- ✅ Reduces spam to users
- ✅ Saves API costs  
- ✅ Maintains visibility via logging
- ✅ Works across all channel types (WhatsApp, Discord, Telegram, Slack)

## Test Plan

- [ ] Configure invalid `CLAUDE_CODE_OAUTH_TOKEN` in `.env`
- [ ] Send message to registered group
- [ ] Verify: error logged in `logs/nanoclaw.log` but NOT sent as message
- [ ] Restore valid token and verify normal responses work
- [ ] Test with multiple channel types (WhatsApp, Discord)

## Upstream

**Based on:** https://github.com/qwibitai/nanoclaw/pull/298
**Tracking:** `/workspace/group/upstream-tracking-2026-02-18-part2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents system and authentication failure messages from being forwarded to channels, reducing noisy notifications and improving error state handling.
* **Chores**
  * Sensitive tokens and common credential fields are now redacted from logs to protect user data and reduce exposure of secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->