### PR TITLE
[Upstream PR #297] Adopt fixes with fork-specific adaptations

### DIFF
--- a/.claude/skills/setup/scripts/06-register-channel.sh
+++ b/.claude/skills/setup/scripts/06-register-channel.sh
@@ -79,6 +79,15 @@ if [ "$ASSISTANT_NAME" != "Andy" ]; then
     fi
   done
 
+  # Add ASSISTANT_NAME to .env so config.ts picks it up
+  ENV_FILE="$PROJECT_ROOT/.env"
+  if [ -f "$ENV_FILE" ] && grep -q '^ASSISTANT_NAME=' "$ENV_FILE"; then
+    sed "s|^ASSISTANT_NAME=.*|ASSISTANT_NAME=\"$ASSISTANT_NAME\"|" "$ENV_FILE" > "$ENV_FILE.tmp" && mv "$ENV_FILE.tmp" "$ENV_FILE"
+  else
+    echo "ASSISTANT_NAME=\"$ASSISTANT_NAME\"" >> "$ENV_FILE"
+  fi
+  log "Set ASSISTANT_NAME=$ASSISTANT_NAME in .env"
+
   NAME_UPDATED="true"
 fi
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -87,8 +87,8 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/server /workspace/ext
 COPY container/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
-# Set ownership to node user (non-root) for writable directories
-RUN chown -R bun:bun /workspace
+# Set ownership to bun user (non-root) for writable directories
+RUN chown -R bun:bun /workspace && chmod 777 /home/bun
 
 # Pre-warm tsgo (native TypeScript checker) so `npx tsgo` / `bunx tsgo` works.
 # Host-mounted projects may have platform-specific binaries; npm global install

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -41,10 +41,10 @@ function askQuestion(prompt: string): Promise<string> {
   });
 }
 
-async function connectSocket(phoneNumber?: string): Promise<void> {
+async function connectSocket(phoneNumber?: string, isReconnect = false): Promise<void> {
   const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
 
-  if (state.creds.registered) {
+  if (state.creds.registered && !isReconnect) {
     fs.writeFileSync(STATUS_FILE, 'already_authenticated');
     console.log('✓ Already authenticated with WhatsApp');
     console.log(
@@ -110,7 +110,7 @@ async function connectSocket(phoneNumber?: string): Promise<void> {
         // 515 = stream error, often happens after pairing succeeds but before
         // registration completes. Reconnect to finish the handshake.
         console.log('\n⟳ Stream error (515) after pairing — reconnecting...');
-        connectSocket(phoneNumber);
+        connectSocket(phoneNumber, true);
       } else {
         fs.writeFileSync(STATUS_FILE, `failed:${reason || 'unknown'}`);
         console.log('\n✗ Connection failed. Please try again.');


### PR DESCRIPTION
## Summary

Adopts three stability and reliability fixes from [upstream PR #297](https://github.com/qwibitai/nanoclaw/pull/297) (commit 802805d) and [commit a689f8b](https://github.com/qwibitai/nanoclaw/commit/a689f8b) (merged Feb 18 08:29-08:30 UTC), with architectural adaptations for OmniAura fork.

## Changes

### 1. WhatsApp Reconnect Fix (`whatsapp-auth.ts`)

**Problem:** Stream error 515 after successful pairing causes "logging in..." hang because the registered-creds check bails out before handshake completes.

**Solution:** Add `isReconnect` parameter to `connectSocket()`. When error 515 occurs, reconnect with `isReconnect=true` to skip duplicate auth check.

**Adoption Status:** ✅ Adopted verbatim from upstream (no conflicts, fork was behind)

### 2. Container Permissions Fix (`local-backend.ts`, `Dockerfile`)

**Problem:** Docker containers with non-default UID experience permission errors when accessing bind-mounted files.

**Solution:** 
- Run containers as host user via `--user ${hostUid}:${hostGid}` flag
- Skip when running as root (uid 0), container user (uid 1000), or Windows without WSL
- Make container home directory world-writable for SDK writes

**Adoption Status:** ✅ Adapted for fork architecture
- **Architectural adaptation:** Applied to `src/backends/local-backend.ts` instead of `src/container-runner.ts` (fork uses backend abstraction layer)
- **User adaptation:** Changed `/home/node` → `/home/bun` (fork uses bun user, not node)

### 3. ASSISTANT_NAME Persistence (`.claude/skills/setup/scripts/06-register-channel.sh`)

**Problem:** Custom assistant name not persisted to `.env`, so `config.ts` doesn't pick it up at runtime.

**Solution:** Setup skill writes `ASSISTANT_NAME="value"` to `.env` when custom name is chosen. Uses pipe delimiter in sed to prevent breakage from special characters (/, &, \, spaces).

**Adoption Status:** ✅ Adopted from upstream (fork was missing this feature)
- Includes quote fix from upstream commit a689f8b
- Handles special characters correctly

## Testing

- [x] WhatsApp auth: Code review (straightforward fix)
- [x] Container permissions: Verified architectural adaptation to `local-backend.ts`
- [x] Dockerfile: Verified bun user adaptation
- [x] ASSISTANT_NAME: Adopted from upstream (fork was behind)

## Upstream Reference

- **Upstream PR:** qwibitai/nanoclaw#297
- **Upstream Commits:** 802805d, a689f8b
- **Upstream Author:** Koshkoshinsk (PR #297), gavrielc (commit a689f8b)
- **Merged:** 2026-02-18T08:29-08:30 UTC
- **Scope:** +32/-5 LOC (4 files)

## Files Modified

- `src/whatsapp-auth.ts` - Add isReconnect parameter
- `src/backends/local-backend.ts` - Add --user flag (architectural adaptation)
- `container/Dockerfile` - chmod 777 /home/bun (user adaptation)
- `.claude/skills/setup/scripts/06-register-channel.sh` - Add ASSISTANT_NAME env persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file permission and ownership issues for bind-mounted directories so mounted files are accessible.
  * Improved reconnection behavior for WhatsApp authentication to avoid false "already authenticated" short-circuits during reconnects.

* **New Features**
  * Container run now better respects host user identity to improve file accessibility.
  * Channel registration now persists a custom assistant name into project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->