### PR TITLE
fix: reply-thread to latest message, not the trigger message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -484,8 +484,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     TRIGGER_PATTERN.test(m.content) ||
     (m.mentions?.some((mention) => botNames.has(mention.name.toLowerCase())) ?? false);
   const triggeringMessage = missedMessages.findLast(isTriggerMessage);
-  const rawMessageId = triggeringMessage?.id || missedMessages[missedMessages.length - 1]?.id || null;
-  const triggeringMessageId = rawMessageId && /^(synth|react|notify|s3)-/.test(rawMessageId) ? null : rawMessageId;
+  // Always reply to the last message in the batch, not the triggering message.
+  // triggeringMessage is used to decide whether to process; the reply should
+  // thread to what the user most recently said.
+  const lastMessageId = missedMessages[missedMessages.length - 1]?.id || triggeringMessage?.id || null;
+  const triggeringMessageId = lastMessageId && /^(synth|react|notify|s3)-/.test(lastMessageId) ? null : lastMessageId;
   const lastContent = missedMessages[missedMessages.length - 1]?.content || '';
   const threadName = lastContent
     .replace(TRIGGER_PATTERN, '').trim().slice(0, 80) || 'Agent working...';


### PR DESCRIPTION
## Summary

- *Root cause*: When a batch of messages included a trigger (e.g. `@PeytonOmni how are you`) followed by non-trigger messages (e.g. `im good 🙂`), `findLast(isTriggerMessage)` returned the trigger message's ID as the reply target — so the bot threaded its response to an older message instead of the most recent one.
- *Fix*: Always use the last message in the batch as `triggeringMessageId`. The trigger message still controls *whether* to process the batch, but the reply should always thread to what the user most recently said.

## Test plan

- [x] All 113 existing tests pass
- [x] No new TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated group message threading behavior. When multiple messages are processed together, replies now thread to the most recent message in the batch instead of the original triggering message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->