### PR TITLE
fix: per-group trigger pattern for message routing and bot filtering

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,16 @@ export const TRIGGER_PATTERN = new RegExp(
   'i',
 );
 
+/**
+ * Build a trigger regex for a specific group's trigger string (e.g. "@OmarOmni").
+ * Falls back to the global TRIGGER_PATTERN if no trigger is provided.
+ */
+export function buildTriggerPattern(trigger?: string): RegExp {
+  if (!trigger) return TRIGGER_PATTERN;
+  const name = trigger.replace(/^@/, '');
+  return new RegExp(`^@${escapeRegex(name)}\\b`, 'i');
+}
+
 // Timezone for scheduled tasks (cron expressions, etc.)
 // Uses system timezone by default
 export const TIMEZONE =

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   B2_ENDPOINT,
   B2_REGION,
   B2_SECRET_ACCESS_KEY,
+  buildTriggerPattern,
   DATA_DIR,
   DISCORD_BOT_TOKEN,
   GROUPS_DIR,
@@ -742,8 +743,11 @@ async function startMessageLoop(): Promise<void> {
           // Non-trigger messages accumulate in DB and get pulled as
           // context when a trigger eventually arrives.
           if (needsTrigger) {
+            // Use per-group trigger pattern so @PeytonOmni channels aren't
+            // silently dropped by the global @Omni TRIGGER_PATTERN.
+            const groupTriggerPattern = buildTriggerPattern(group.trigger);
             const hasTrigger = groupMessages.some((m) =>
-              TRIGGER_PATTERN.test(m.content.trim()),
+              groupTriggerPattern.test(m.content.trim()),
             );
             if (!hasTrigger) continue;
           }


### PR DESCRIPTION
## Summary

- **Root cause**: Global `TRIGGER_PATTERN` (`/^@Omni\b/`) was used in two critical places, silently dropping messages meant for `@PeytonOmni`, `@OmarOmni`, or any agent with a custom trigger name
- **Fix 1** (`index.ts`): `startMessageLoop` now calls `buildTriggerPattern(group.trigger)` per channel instead of the global pattern — so each agent's channel correctly triggers on its own name
- **Fix 2** (`discord.ts`): Bot-to-bot message filter uses the per-channel trigger, enabling agent-to-agent comms in multi-agent servers
- **New export** (`config.ts`): `buildTriggerPattern(trigger?: string)` helper centralizes the regex logic, falls back to `TRIGGER_PATTERN` if no trigger provided

## Test plan
- [ ] Register two agents with different triggers (e.g. `@PeytonOmni`, `@OmarOmni`) in separate Discord channels
- [ ] Send `@PeytonOmni hello` in PeytonOmni's channel — verify it triggers PeytonOmni (not OmarOmni or nothing)
- [ ] Send `@OmarOmni hello` in OmarOmni's channel — verify it triggers OmarOmni
- [ ] Verify existing main group (`@Omni`) still works as before
- [ ] Test bot-to-bot: one agent mentioning another with the correct trigger name should route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved trigger pattern evaluation by implementing per-channel and per-group pattern matching, replacing the global pattern approach for more consistent message filtering across different conversation contexts.

* **New Features**
  * Added buildTriggerPattern utility function to generate group-specific trigger patterns, enabling flexible trigger configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->