### PR TITLE
fix: use per-group trigger in processGroupMessages (missed by PR #138)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -373,10 +373,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   if (missedMessages.length === 0) return true;
 
-  // For non-main groups, check if trigger is required and present
+  // For non-main groups, check if trigger is required and present.
+  // Use buildTriggerPattern(group.trigger) so @PeytonOmni / @OmarOmni groups
+  // aren't silently dropped by the global @Omni TRIGGER_PATTERN (mirrors the
+  // same fix already applied in startMessageLoop by PR #138).
   if (!isMainGroup && group.requiresTrigger !== false) {
+    const groupTriggerPattern = buildTriggerPattern(group.trigger);
     const hasTrigger = missedMessages.some((m) =>
-      TRIGGER_PATTERN.test(m.content.trim()),
+      groupTriggerPattern.test(m.content.trim()),
     );
     if (!hasTrigger) return true;
   }


### PR DESCRIPTION
## Summary

- PR #138 fixed `startMessageLoop` to call `buildTriggerPattern(group.trigger)` instead of the global `TRIGGER_PATTERN`, but `processGroupMessages` still used the global pattern in its early-exit `hasTrigger` guard
- Groups with custom triggers (`@PeytonOmni`, `@OmarOmni`) would pass the `startMessageLoop` gate (fixed by #138) but then silently drop inside `processGroupMessages` when the global `@Omni` regex didn't match their trigger name
- One-line fix: replace `TRIGGER_PATTERN.test(m.content.trim())` with `buildTriggerPattern(group.trigger).test(m.content.trim())` — consistent with the pattern PR #138 established

This is the only remaining unique fix from PR #132, extracted as a focused single-file change.

## Test plan

- [ ] Register two agents with different triggers (e.g. `@PeytonOmni`, `@OmarOmni`) in separate groups
- [ ] Send `@PeytonOmni hello` to PeytonOmni's group — verify it triggers (was silently dropped before this fix)
- [ ] Send `@OmarOmni hello` to OmarOmni's group — verify it triggers
- [ ] Verify existing main group (`@Omni`) still works as before
- [ ] Run `bun test` — all existing tests should pass (no new tests needed; logic mirrors #138 which has existing test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Groups with custom trigger requirements now correctly evaluate messages against their specific trigger patterns instead of the global default. This improvement ensures proper message processing and routing for groups with non-standard triggers, allowing them to be accurately identified and processed when their particular trigger conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->